### PR TITLE
Fix for Undefined offset warning

### DIFF
--- a/QRmask.php
+++ b/QRmask.php
@@ -165,7 +165,7 @@ class QRmask {
 
 		for($y=0; $y<$width; $y++) {
 			for($x=0; $x<$width; $x++) {
-				if($bitMask[$y][$x] == 1) {
+				if(isset($bitMask[$y][$x]) && $bitMask[$y][$x] == 1) {
 					$d[$y][$x] = chr(ord($s[$y][$x]) ^ (int)$bitMask[$y][$x]);
 				}
 				$b += (int)(ord($d[$y][$x]) & 1);


### PR DESCRIPTION
The following warning appears when I use this QRcode generator for TOTP codes (2FA): 
"Undefined offset: 36 in /var/www/html/lib/php/qrcode/qrmask.php on line 168"

This small addition prevents the error from clogging my log file. The QR image was still being generated correctly.